### PR TITLE
Replace all logics for task generation

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -14171,7 +14171,7 @@ MonoBehaviour:
         m_CallState: 2
       - m_Target: {fileID: 294665252}
         m_TargetAssemblyTypeName: NavigateManager, Assembly-CSharp
-        m_MethodName: GenerateTask
+        m_MethodName: GenerateTaskFromQueue
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scripts/Manager/NavigateManager.cs
+++ b/Assets/Scripts/Manager/NavigateManager.cs
@@ -121,6 +121,7 @@ public class NavigateManager : Singleton<NavigateManager>
         UIElementReference.Instance.m_confirmButton.SetActive(true);
     }
 
+    // Unused method, can be safely removed or comment out
     public void GenerateTask()
     {
         // Prevents from infinite loop


### PR DESCRIPTION
All usages of GenerateTask is now replaced by GenerateTaskFromQueue.

GenerateTaskFromQueue generates task with no loop involved, it's guaranteed to produce an incomplete task when called.

GenerateTask is now redundant and can be safely removed.